### PR TITLE
style: add missing SPDX headers

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024 XWiki CryptPad Team <contact@cryptpad.org> and contributors
 module.exports = {
     infra: {
         ws: [{


### PR DESCRIPTION
config.js lacked SPDX headers as well