### PR TITLE
config: rename "address" to "host"

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,18 +3,18 @@
 module.exports = {
     infra: {
         ws: [{
-            address: 'localhost',
+            host: 'localhost',
             port: 3010
         }],
         core: [{
-            address: 'localhost',
+            host: 'localhost',
             port: 3011
         }, {
-            address: 'localhost',
+            host: 'localhost',
             port: 3012
         }],
         storage: [{
-            address: 'localhost',
+            host: 'localhost',
             port: 3014
         }]
     }

--- a/websocket/index.js
+++ b/websocket/index.js
@@ -7,13 +7,13 @@ const ChainpadServer = require('chainpad-server');
 const Config = require("../config.js");
 
 let config = {
-    address: '::',
+    host: '::',
     port: '3000'
 };
 
 let app = Express();
 let httpServer = Http.createServer(app);
-httpServer.listen(config.port, config.address, function() {
+httpServer.listen(config.port, config.host, function() {
     console.log('server started');
 });
 


### PR DESCRIPTION
This aligns config variables with server.listen() parameter names.

See:
https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback

(And perhaps "host" is less ambiguous generally; in some contexts "address" can imply "ip address" and other times it can mean "endpoint address" would include host, port, and path.)