### PR TITLE
Backport of CryptPad #2346: remove expiry upon restoring a pad (if expired)

### DIFF
--- a/storage/storage/file.js
+++ b/storage/storage/file.js
@@ -858,7 +858,7 @@ var unarchiveChannel = function (env, channelName, cb) {
             if (err && err.code === 'ENOENT') {
                 if (ENOENT) {
                     // nothing was deleted? the client probably wants to know about that.
-                    return void cb("ENOENT");
+                    return void CB("ENOENT");
                 }
                 return CB();
             }
@@ -868,7 +868,32 @@ var unarchiveChannel = function (env, channelName, cb) {
                 return void CB(labelError("E_METADATA_RESTORATION", err));
             }
             // otherwise it was moved successfully
-            CB();
+
+            // remove the `expire` date if it is overdue (probably mistakenly
+            // expired pad)
+            Fs.readFile(metadataPath, (readError, content) => {
+                if (readError) {
+                    if (readError.code === 'ENOENT') { return void CB(); }
+                    return CB(labelError("E_METADATA_RESTORATION", readError));
+                }
+                try {
+                    let metadataArray = content.toString().split('\n');
+                    let metadata = JSON.parse(metadataArray[0]);
+                    let expireDate = metadata?.expire;
+                    // check that it’s indeed expired
+                    if (expireDate && +new Date() >= expireDate) {
+                        delete metadata.expire;
+                        metadataArray[0] = JSON.stringify(metadata);
+                        return Fs.writeFile(metadataPath, metadataArray.join('\n'), CB);
+                    }
+                    CB();
+                }
+                catch(err) {
+                    // Most probably a JSON.parse error: invalid metadata
+                    // The file would have been restored “as is” at this point
+                    CB('INVALID_METADATA');
+                };
+            });
         }));
     });
 };


### PR DESCRIPTION
Remove `expire` property from metadata if the document has expired.

Backport of: https://github.com/cryptpad/cryptpad/pull/2346